### PR TITLE
Fix Community Solid Server usage instructions

### DIFF
--- a/solid/README.md
+++ b/solid/README.md
@@ -17,7 +17,7 @@ If you want to play around with the application, you'll need to log into a [Soli
 
 ```sh
 npm install -g @solid/community-server
-community-solid-server -c @css:config/file.json -p 4000 -f ./solid-pod
+community-solid-server -c @css:config/file-no-setup.json -p 4000 -f ./solid-pod
 ```
 
 If you want to modify the code, you'll also need to serve the application in a url. You could just open the `index.html` file in a browser, but unfortunately that will not work because the authentication flow performs a redirect and that won't work with a website being served with the `file://` protocol.


### PR DESCRIPTION
The default configuration changed in the latest release of the community server and the previous instructions no longer work.

This new command should work in the upcoming release, as discussed in https://github.com/solid/community-server/issues/1102.